### PR TITLE
Usage without django_microsoft_sso installed

### DIFF
--- a/django_github_sso/utils.py
+++ b/django_github_sso/utils.py
@@ -1,11 +1,15 @@
 from django.contrib import messages
-from django_microsoft_sso import conf
 from loguru import logger
+
+try:
+    from django_microsoft_sso import conf
+except ImportError:
+    conf = None
 
 
 def send_message(request, message, level: str = "error"):
     getattr(logger, level.lower())(message)
-    if conf.MICROSOFT_SSO_ENABLE_MESSAGES:
+    if conf and conf.MICROSOFT_SSO_ENABLE_MESSAGES:
         messages.add_message(request, getattr(messages, level.upper()), message)
 
 


### PR DESCRIPTION
### Contains
- [ ] Breaking Changes
- [ ] New/Update documentation
- [ ] CI/CD modifications

### Changes
*  Added possibility to use this module without `django_microsoft_sso` being installed.

### Resolves
Resolves `ModuleNotFoundError: No module named 'django_microsoft_sso'` that happens when the package `django_microsoft_sso` is not installed.
